### PR TITLE
Client/parse url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "5"

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ node index.js -c localhost:5050 localhost:5051 localhost:5052 -s lorem -f lorem-
 * `-c` or `--client` to set one or more clients
 * `-s` or `--search` to set the word that will be searched
 * `-f` or `--file` to set the file that will be used (path to file)
+
+
+## Testing
+
+```console
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ Created for Feevale University Distributed Systems Course on year 2015.
 ## How to run
 
 ```console
-node index.js -c localhost:5050 localhost:5051 localhost:5052 -s lorem -f lorem-ipsum.txt
+node index.js -c \
+  http://localhost:5050 \
+  http://localhost:5051 \
+  http://localhost:5052 \
+  -s lorem \
+  -f lorem-ipsum.txt
 ```
 
 ### Options

--- a/lib/client_parse.js
+++ b/lib/client_parse.js
@@ -2,6 +2,11 @@ var url = require('url');
 
 /**
  * Parse a client url creating the http.request options
+ *
+ * Usage:
+ *   var options = client_parse('http://localhost:3000');
+ *   http.request(options, callback);
+ *
  * @return {object} options
  */
 function client_parse(address) {

--- a/lib/client_parse.js
+++ b/lib/client_parse.js
@@ -1,0 +1,12 @@
+var url = require('url');
+
+/**
+ * Parse a client url creating the http.request options
+ * @return {object} options
+ */
+function client_parse(address) {
+  var options = url.parse(address);
+  return options;
+}
+
+module.exports = client_parse;

--- a/lib/client_parse.js
+++ b/lib/client_parse.js
@@ -6,6 +6,12 @@ var url = require('url');
  */
 function client_parse(address) {
   var options = url.parse(address);
+
+  options.method  = 'POST';
+  options.headers = options.headers || {};
+
+  options.headers['Content-Type'] = 'application/json';
+
   return options;
 }
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,20 @@
     }
   ],
   "license": "MIT",
+  "scripts": {
+    "test": "mocha test/bootstrap.test.js test/**/*_spec.coffee",
+    "test-debug": "mocha debug test/bootstrap.test.js test/**/*_spec.coffee"
+  },
   "bugs": {
     "url": "https://github.com/samuelreichert/feevale-servidor-sistemas-distribuidos/issues"
   },
   "homepage": "https://github.com/samuelreichert/feevale-servidor-sistemas-distribuidos#readme",
   "dependencies": {
     "yargs": "^3.30.0"
+  },
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "coffee-script": "^1.10.0",
+    "mocha": "^2.3.4"
   }
 }

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = 'test';
+
+global.expect  = require('chai').expect;

--- a/test/lib/client_parse_spec.coffee
+++ b/test/lib/client_parse_spec.coffee
@@ -1,0 +1,21 @@
+client_parse = require('../../lib/client_parse')
+
+describe 'client_parse', ->
+  it 'is a function', ->
+    expect(client_parse).to.be.a 'function'
+
+  before ->
+    @client_url = 'http://example.com:8082/'
+    @options = client_parse(@client_url)
+
+  it 'parses protocol', ->
+    expect(@options.protocol).to.eql 'http:'
+
+  it 'parses hostname', ->
+    expect(@options.hostname).to.eql 'example.com'
+
+  it 'parses port', ->
+    expect(@options.port).to.eql '8082'
+
+  it 'parses path', ->
+    expect(@options.path).to.eql '/'

--- a/test/lib/client_parse_spec.coffee
+++ b/test/lib/client_parse_spec.coffee
@@ -19,3 +19,9 @@ describe 'client_parse', ->
 
   it 'parses path', ->
     expect(@options.path).to.eql '/'
+
+  it 'sets method to POST', ->
+    expect(@options.method).to.eql 'POST'
+
+  it 'sets Content-type to application/json', ->
+    expect(@options.headers).to.have.property 'Content-Type', 'application/json'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require coffee-script/register
+--compilers coffee:coffee-script/register
+--reporter spec


### PR DESCRIPTION
- Adiciona módulo para fazer parse das urls de clients
- Adiciona testes usando mocha + chai

Reparem como é criado o módulo e como é utilizado nos testes.
Ele apenas retorna uma função Javascript que pode ser utilizada normalmente após o `require()`.
